### PR TITLE
ext/x25519_precomputed: Fix compare_bytes()

### DIFF
--- a/ext/x25519_precomputed/fp25519_x64.c
+++ b/ext/x25519_precomputed/fp25519_x64.c
@@ -23,7 +23,7 @@ int compare_bytes(uint8_t* A, uint8_t* B,unsigned int num_bytes)
 	uint8_t ret=0;
 	for(i=0;i<num_bytes;i++)
 	{
-		ret += A[i]^B[i];
+		ret |= A[i]^B[i];
 	}
 	return ret;
 }


### PR DESCRIPTION
With the previous code, it was possible for `compare_bytes()` to return `0` even with different inputs.

This change mirrors an upstream fix found in this PR:

https://github.com/armfazh/rfc7748_precomputed/pull/1