### PR TITLE
Delete dead code

### DIFF
--- a/ext/x25519_precomputed/fp25519_x64.c
+++ b/ext/x25519_precomputed/fp25519_x64.c
@@ -17,22 +17,6 @@
 */
 #include "fp25519_x64.h"
 
-int compare_bytes(uint8_t* A, uint8_t* B,unsigned int num_bytes)
-{
-	unsigned int i=0;
-	uint8_t ret=0;
-	for(i=0;i<num_bytes;i++)
-	{
-		ret |= A[i]^B[i];
-	}
-	return ret;
-}
-
-int compare_EltFp25519_1w_x64(uint64_t *A, uint64_t *B)
-{
-	return compare_bytes((uint8_t*)A,(uint8_t*)B,SIZE_ELEMENT_BYTES);
-}
-
 /**
  *
  * @param c Two 512-bit products: c[0:7]=a[0:3]*b[0:3] and c[8:15]=a[4:7]*b[4:7]

--- a/ext/x25519_precomputed/fp25519_x64.h
+++ b/ext/x25519_precomputed/fp25519_x64.h
@@ -45,9 +45,6 @@ void red_EltFp25519_1w_x64(uint64_t *const c, uint64_t *const a);
 
 /* Prime Field Util */
 void random_EltFp25519_1w_x64(uint64_t *A);
-int compare_EltFp25519_1w_x64(uint64_t *A, uint64_t *B);
-void random_EltFp25519_2w_x64(uint64_t *A);
-int compare_EltFp25519_2w(uint64_t *A, uint64_t *B);
 
 /* Prime Field Arithmetic */
 void add_EltFp25519_1w_x64(uint64_t *const c, uint64_t *const a, uint64_t *const b);


### PR DESCRIPTION
This code in particular contained an upstream bug:

https://github.com/armfazh/rfc7748_precomputed/pull/1

It's not used at all in this library though, so delete it rather than fixing it.